### PR TITLE
iOS input zoom-in 현상 방지

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,11 +1,18 @@
 import { Global } from '@emotion/react';
 import type { AppProps } from 'next/app';
+import Head from 'next/head';
 import { Layout } from '../components/layouts/Layout';
 import { GlobalStyles } from '../styles/globals';
 
 function MyApp({ Component, pageProps }: AppProps) {
   return (
     <>
+      <Head>
+        <meta
+          name="viewport"
+          content="width=device-width, initial-scale=1, minimum-scale=1, maximum-scale=1, viewport-fit=cover"
+        />
+      </Head>
       <Global styles={GlobalStyles} />
       <Layout>
         <Component {...pageProps} />


### PR DESCRIPTION
## 개요
- 아이폰에서 input에 포커스가 되었을 때 자동으로 zoon-in이 되는 현상 발생
- 원인 : 폰트 사이즈가 16px 보다 작을 경우 발생하는 문제

## 이슈 번호
close #100 

## 작업 내용
-  iOS input 포커스 시 자동 zoom-in 현상 방지

## 기타
