### PR TITLE
로그인 페이지에 네비게이션 바 보이지 않게 처리

### DIFF
--- a/src/components/layouts/Layout.tsx
+++ b/src/components/layouts/Layout.tsx
@@ -1,3 +1,4 @@
+import { useRouter } from 'next/router';
 import { ReactChild } from 'react';
 import { Navigation } from './Navigation';
 
@@ -6,10 +7,12 @@ interface LayoutProps {
 }
 
 export const Layout = ({ children }: LayoutProps) => {
+  const router = useRouter();
+  const { pathname } = router;
   return (
     <>
       <main>{children}</main>
-      <Navigation />
+      {pathname !== '/' && <Navigation />}
     </>
   );
 };


### PR DESCRIPTION
## 개요
- Layout을 적용하면서 모든 페이지에 네비게이션 바가 적용
- 로그인 페이지에서는 네비게이션 바가 노출되지 않아야 한다.
- pathname에 따라 네비게이션 바 노출 여부 적용

## 이슈 번호
#102 

## 작업 내용
- [x] 로그인 페이지에 네비게이션 바 보이지 않게 처리

## 참고
- [Layouts](https://nextjs.org/docs/basic-features/layouts)
- [[NextJs] getLayout 적용하기](https://velog.io/@sssssssssy/getLayout)
