### PR TITLE
프로필 이미지 클릭 시 해당 계정 프로필로 이동

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -28,6 +28,7 @@
   "plugins": ["@typescript-eslint", "react", "react-hooks", "prettier"],
   "ignorePatterns": ["src/frontend/generated/*", "apollo.config.js"],
   "rules": {
+    "react/require-default-props": "off",
     "react/react-in-jsx-scope": 0,
     "react/prefer-stateless-function": 0,
     "react/jsx-filename-extension": 0,

--- a/src/components/UserAvatar.tsx
+++ b/src/components/UserAvatar.tsx
@@ -1,17 +1,30 @@
-// import { css } from '@emotion/react';
 import styled from '@emotion/styled';
+import Link from 'next/link';
 import { GRAY_300 } from '../constants/colors';
 
-type AvatarProps = {
+interface StyleProps {
   size: string;
   src: string;
-};
+}
 
-export const UserAvatar = ({ size, src }: AvatarProps) => {
+interface UserAvatarProps extends StyleProps {
+  accountName?: string;
+}
+
+export const UserAvatar = ({ size, src, accountName }: UserAvatarProps) => {
+  if (accountName) {
+    return (
+      <Link href={`/profile/${accountName}`} passHref>
+        <a>
+          <ImgProfile size={size} src={src} alt="사용자 프로필 이미지" />
+        </a>
+      </Link>
+    );
+  }
   return <ImgProfile size={size} src={src} alt="사용자 프로필 이미지" />;
 };
 
-const ImgProfile = styled.img<AvatarProps>`
+const ImgProfile = styled.img<StyleProps>`
   width: ${(props) => props.size};
   height: ${(props) => props.size};
   border-radius: 50%;

--- a/src/components/feed/FeedCard.tsx
+++ b/src/components/feed/FeedCard.tsx
@@ -122,7 +122,11 @@ export const FeedCard = ({ postData }: PostProps) => {
     <>
       <Feed>
         <BoxProfileImg>
-          <UserAvatar size={USER_AVATAR.sm.size} src={profileImg} />
+          <UserAvatar
+            size={USER_AVATAR.sm.size}
+            src={profileImg}
+            accountName={authorAccountname}
+          />
         </BoxProfileImg>
         <HeaderArticle>
           <UserName>{username}</UserName>

--- a/src/components/follow/FollowerCard.tsx
+++ b/src/components/follow/FollowerCard.tsx
@@ -2,7 +2,6 @@ import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import axios from 'axios';
 import Cookies from 'js-cookie';
-import Link from 'next/link';
 import { useState } from 'react';
 import { API_ENDPOINT, BORDER, USER_AVATAR } from '../../constants';
 import { GRAY_900, PRIMARY, WHITE } from '../../constants/colors';
@@ -46,15 +45,17 @@ export const FollowerCard = ({ followerData }: FollowerProps) => {
 
   return (
     <Follower>
-      <Link href={`/profile/${accountname}`} passHref>
-        <LinkFollower>
-          <UserAvatar size={USER_AVATAR.md.size} src={image} />
-          <FollowerAccount>
-            <FollowerName>{username}</FollowerName>
-            <FollowerId>@{accountname}</FollowerId>
-          </FollowerAccount>
-        </LinkFollower>
-      </Link>
+      <MetaContainer>
+        <UserAvatar
+          size={USER_AVATAR.md.size}
+          src={image}
+          accountName={accountname}
+        />
+        <FollowerAccount>
+          <FollowerName>{username}</FollowerName>
+          <FollowerId>@{accountname}</FollowerId>
+        </FollowerAccount>
+      </MetaContainer>
       {followed ? (
         <BtnCancel type="button" onClick={() => removeFollow(accountname)}>
           팔로잉
@@ -74,7 +75,7 @@ const Follower = styled.li`
   gap: 10px;
 `;
 
-const LinkFollower = styled.a`
+const MetaContainer = styled.div`
   display: grid;
   grid-template-columns: 50px auto;
   gap: 10px;

--- a/src/components/follow/FollowingCard.tsx
+++ b/src/components/follow/FollowingCard.tsx
@@ -2,7 +2,6 @@ import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import axios from 'axios';
 import Cookies from 'js-cookie';
-import Link from 'next/link';
 import { useState } from 'react';
 import { BORDER, USER_AVATAR, API_ENDPOINT } from '../../constants';
 import { GRAY_900, PRIMARY, WHITE } from '../../constants/colors';
@@ -45,15 +44,17 @@ export const FollowingCard = ({ followingData }: FollowingProps) => {
 
   return (
     <Following>
-      <Link href={`/profile/${accountname}`} passHref>
-        <LinkFollowing>
-          <UserAvatar size={USER_AVATAR.md.size} src={image} />
-          <FollowingAccount>
-            <FollowingName>{username}</FollowingName>
-            <FollowingId>@{accountname}</FollowingId>
-          </FollowingAccount>
-        </LinkFollowing>
-      </Link>
+      <MetaContainer>
+        <UserAvatar
+          size={USER_AVATAR.md.size}
+          src={image}
+          accountName={accountname}
+        />
+        <FollowingAccount>
+          <FollowingName>{username}</FollowingName>
+          <FollowingId>@{accountname}</FollowingId>
+        </FollowingAccount>
+      </MetaContainer>
       {followed ? (
         <BtnCancel type="button" onClick={() => removeFollow(accountname)}>
           팔로잉
@@ -73,7 +74,7 @@ const Following = styled.li`
   gap: 10px;
 `;
 
-const LinkFollowing = styled.a`
+const MetaContainer = styled.div`
   display: grid;
   grid-template-columns: 50px auto;
   gap: 10px;

--- a/src/components/post/CommentCard.tsx
+++ b/src/components/post/CommentCard.tsx
@@ -83,7 +83,11 @@ export const CommentCard = ({
   return (
     <Container>
       <CommentBox>
-        <UserAvatar size={USER_AVATAR.xs.size} src={image} />
+        <UserAvatar
+          size={USER_AVATAR.xs.size}
+          src={image}
+          accountName={authorAccountname}
+        />
         <User>
           <UserName>{username}</UserName>
           <Timestamp>{dateFormatter(createdAt)}</Timestamp>

--- a/src/components/post/PostCard.tsx
+++ b/src/components/post/PostCard.tsx
@@ -123,7 +123,11 @@ export const PostCard = ({ postData }: PostCardProps) => {
       <Feed>
         <h2 className="sr-only">피드 보기</h2>
         <BoxProfileImg>
-          <UserAvatar size={USER_AVATAR.sm.size} src={profileImg} />
+          <UserAvatar
+            size={USER_AVATAR.sm.size}
+            src={profileImg}
+            accountName={authorAccountname}
+          />
         </BoxProfileImg>
         <HeaderArticle>
           <UserName>{username}</UserName>

--- a/src/pages/user/search.tsx
+++ b/src/pages/user/search.tsx
@@ -66,22 +66,17 @@ const SearchUser: NextPage = () => {
             userList.map((user) => {
               const { _id, accountname, username, image } = user;
               return (
-                <li key={`user-list-${_id}`}>
-                  <Link href={`/profile/${accountname}`} passHref>
-                    <LinkUser>
-                      <UserAvatar
-                        size={USER_AVATAR.md.size}
-                        src={
-                          image?.length > 0 ? image : '/default-profile-w.png'
-                        }
-                      />
-                      <UserAccount>
-                        <UserName>{handleHighlight(username)}</UserName>
-                        <UserId>@{accountname}</UserId>
-                      </UserAccount>
-                    </LinkUser>
-                  </Link>
-                </li>
+                <UserContainer key={`user-list-${_id}`}>
+                  <UserAvatar
+                    size={USER_AVATAR.md.size}
+                    src={image?.length > 0 ? image : '/default-profile-w.png'}
+                    accountName={accountname}
+                  />
+                  <UserAccount>
+                    <UserName>{handleHighlight(username)}</UserName>
+                    <UserId>@{accountname}</UserId>
+                  </UserAccount>
+                </UserContainer>
               );
             })}
         </ListUser>
@@ -116,7 +111,7 @@ const ListUser = styled.ul`
   padding: 20px 0;
 `;
 
-const LinkUser = styled.a`
+const UserContainer = styled.li`
   display: grid;
   grid-template-columns: 50px auto;
   gap: 10px;


### PR DESCRIPTION
## 개요
- UserAvatar 컴포넌트에 accountName 속성 추가하여 accountName 속성을 전달받은 경우 해당 프로필 페이지로 이동할 수 있게 라우팅 처리
- default props를 지정해야하는 ESLint rule off 처리
- UserAvatar 컴포넌트에 accountName 속성 추가하면서 일부 페이지에 각각 적용되어 있던 Link 태그 삭제

## 이슈 번호
close #105 

## 작업 내용
- ESLint rule react/require-default-props: off 적용
- UserAvatar 컴포넌트에 accountName 속성 추가
- 사용 중인 일부 UserAvatar 컴포넌트에 accountName 속성 적용

## 기타
