### PR TITLE
네비게이션 바 일부 페이지 노출되지 않게 수정

### DIFF
--- a/public/icons/nav/post-fill.svg
+++ b/public/icons/nav/post-fill.svg
@@ -1,0 +1,5 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect x="3" y="3" width="18" height="18" rx="3" fill="#528540" stroke="#528540" stroke-width="2"/>
+<path d="M12 8V16" stroke="white" stroke-width="2" stroke-linecap="round"/>
+<path d="M8 12L16 12" stroke="white" stroke-width="2" stroke-linecap="round"/>
+</svg>

--- a/src/components/layouts/Layout.tsx
+++ b/src/components/layouts/Layout.tsx
@@ -1,18 +1,9 @@
-import { useRouter } from 'next/router';
-import { ReactChild } from 'react';
-import { Navigation } from './Navigation';
+import { ReactNode } from 'react';
 
 interface LayoutProps {
-  children: ReactChild;
+  children: ReactNode;
 }
 
 export const Layout = ({ children }: LayoutProps) => {
-  const router = useRouter();
-  const { pathname } = router;
-  return (
-    <>
-      <main>{children}</main>
-      {pathname !== '/' && <Navigation />}
-    </>
-  );
+  return <main>{children}</main>;
 };

--- a/src/components/layouts/Navigation.tsx
+++ b/src/components/layouts/Navigation.tsx
@@ -98,6 +98,9 @@ const LinkMenu = styled.a`
   &.chat.active {
     background-image: url('/icons/nav/chat-fill.svg');
   }
+  &.post.active {
+    background-image: url('/icons/nav/post-fill.svg');
+  }
   &.profile.active {
     background-image: url('/icons/nav/profile-fill.svg');
   }

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,10 +1,21 @@
 import { Global } from '@emotion/react';
+import { NextPage } from 'next';
 import type { AppProps } from 'next/app';
 import Head from 'next/head';
-import { Layout } from '../components/layouts/Layout';
+import { ReactElement, ReactNode } from 'react';
 import { GlobalStyles } from '../styles/globals';
 
-function MyApp({ Component, pageProps }: AppProps) {
+export type NextPageWithLayout = NextPage & {
+  getLayout?: (page: ReactElement) => ReactNode;
+};
+
+type AppPropsWithLayout = AppProps & {
+  Component: NextPageWithLayout;
+};
+
+function MyApp({ Component, pageProps }: AppPropsWithLayout) {
+  const getLayout = Component.getLayout || ((page) => page);
+
   return (
     <>
       <Head>
@@ -14,9 +25,7 @@ function MyApp({ Component, pageProps }: AppProps) {
         />
       </Head>
       <Global styles={GlobalStyles} />
-      <Layout>
-        <Component {...pageProps} />
-      </Layout>
+      {getLayout(<Component {...pageProps} />)}
     </>
   );
 }

--- a/src/pages/chat/index.tsx
+++ b/src/pages/chat/index.tsx
@@ -1,17 +1,19 @@
 import styled from '@emotion/styled';
 import Cookies from 'js-cookie';
-import { NextPage } from 'next';
 import Head from 'next/head';
+import { ReactElement } from 'react';
 import useSWR from 'swr';
 import { ChatCard } from '../../components/chat/ChatCard';
 import { Loader } from '../../components/common/Loader';
+import { Layout } from '../../components/layouts/Layout';
 import { Navigation } from '../../components/layouts/Navigation';
 import { ToolBar } from '../../components/layouts/ToolBar';
 import { API_ENDPOINT } from '../../constants';
 import { UserData } from '../../types/UserData';
 import { fetcher } from '../../utils';
+import { NextPageWithLayout } from '../_app';
 
-const ChatListPage: NextPage = () => {
+const ChatListPage: NextPageWithLayout = () => {
   const accountname = Cookies.get('accountname');
   const { data: followerData, error } = useSWR(
     `${API_ENDPOINT}/profile/${accountname}/follower`,
@@ -41,6 +43,15 @@ const ChatListPage: NextPage = () => {
         </ListChats>
       </MainListChat>
     </>
+  );
+};
+
+ChatListPage.getLayout = function getLayout(page: ReactElement) {
+  return (
+    <Layout>
+      {page}
+      <Navigation />
+    </Layout>
   );
 };
 

--- a/src/pages/home/index.tsx
+++ b/src/pages/home/index.tsx
@@ -1,19 +1,21 @@
 import styled from '@emotion/styled';
 import Cookies from 'js-cookie';
-import { NextPage } from 'next';
 import Head from 'next/head';
 import Link from 'next/link';
+import { ReactElement } from 'react';
 import useSWR from 'swr';
 import { Loader } from '../../components/common/Loader';
 import { FeedContainer } from '../../components/feed/FeedContainer';
+import { Layout } from '../../components/layouts/Layout';
 import { Navigation } from '../../components/layouts/Navigation';
 import { ToolBar } from '../../components/layouts/ToolBar';
 import { SplashScreen } from '../../components/SplashScreen';
 import { API_ENDPOINT, BUTTON } from '../../constants';
 import { WHITE } from '../../constants/colors';
 import { fetcher } from '../../utils';
+import { NextPageWithLayout } from '../_app';
 
-const Home: NextPage = () => {
+const Home: NextPageWithLayout = () => {
   const accountname = Cookies.get('accountname');
   const { data, error } = useSWR(
     `${API_ENDPOINT}/profile/${accountname}`,
@@ -51,6 +53,15 @@ const Home: NextPage = () => {
       <Navigation />
       <SplashScreen />
     </>
+  );
+};
+
+Home.getLayout = function getLayout(page: ReactElement) {
+  return (
+    <Layout>
+      {page}
+      <Navigation />
+    </Layout>
   );
 };
 

--- a/src/pages/post/index.tsx
+++ b/src/pages/post/index.tsx
@@ -1,13 +1,13 @@
 import styled from '@emotion/styled';
 import axios from 'axios';
 import Cookies from 'js-cookie';
-import { NextPage } from 'next';
 import Head from 'next/head';
 import { useRouter } from 'next/router';
-import { useEffect, useRef, useState } from 'react';
+import { ReactElement, useEffect, useRef, useState } from 'react';
 import { SubmitHandler, useForm } from 'react-hook-form';
 import useSWR from 'swr';
 import { Loader } from '../../components/common/Loader';
+import { Layout } from '../../components/layouts/Layout';
 import { Navigation } from '../../components/layouts/Navigation';
 import { ToolBar } from '../../components/layouts/ToolBar';
 import { handleTextarea } from '../../components/post/handleTextarea';
@@ -16,8 +16,9 @@ import { API_ENDPOINT, BUTTON, USER_AVATAR } from '../../constants';
 import { GRAY_400 } from '../../constants/colors';
 import { PostData } from '../../types';
 import { fetcher } from '../../utils/fetcher';
+import { NextPageWithLayout } from '../_app';
 
-const UploadPostPage: NextPage = () => {
+const UploadPostPage: NextPageWithLayout = () => {
   const router = useRouter();
 
   const token = Cookies.get('token');
@@ -168,8 +169,16 @@ const UploadPostPage: NextPage = () => {
           </ImageList>
         </ImageContainer>
       </Section>
-      <Navigation />
     </>
+  );
+};
+
+UploadPostPage.getLayout = function getLayout(page: ReactElement) {
+  return (
+    <Layout>
+      {page}
+      <Navigation />
+    </Layout>
   );
 };
 

--- a/src/pages/profile/[id].tsx
+++ b/src/pages/profile/[id].tsx
@@ -1,8 +1,8 @@
 import styled from '@emotion/styled';
-import { NextPage } from 'next';
 import Head from 'next/head';
 import { useRouter } from 'next/router';
 import useSWR from 'swr';
+import { ReactElement } from 'react';
 import { Loader } from '../../components/common/Loader';
 import { Navigation } from '../../components/layouts/Navigation';
 import { ToolBar } from '../../components/layouts/ToolBar';
@@ -11,8 +11,10 @@ import { SectionProducts } from '../../components/SectionProducts';
 import { SectionUserInfo } from '../../components/SectionUserInfo';
 import { API_ENDPOINT } from '../../constants';
 import { fetcher } from '../../utils';
+import { Layout } from '../../components/layouts/Layout';
+import { NextPageWithLayout } from '../_app';
 
-const MyProfile: NextPage = () => {
+const MyProfile: NextPageWithLayout = () => {
   const router = useRouter();
   const { id } = router.query;
   const { data, error } = useSWR(`${API_ENDPOINT}/profile/${id}`, fetcher);
@@ -54,6 +56,15 @@ const MyProfile: NextPage = () => {
         <SectionFeed accountname={accountname} />
       </MainMyPage>
     </>
+  );
+};
+
+MyProfile.getLayout = function getLayout(page: ReactElement) {
+  return (
+    <Layout>
+      {page}
+      <Navigation />
+    </Layout>
   );
 };
 

--- a/src/pages/profile/index.tsx
+++ b/src/pages/profile/index.tsx
@@ -1,10 +1,9 @@
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import Cookies from 'js-cookie';
-import { NextPage } from 'next';
 import Head from 'next/head';
 import router from 'next/router';
-import { MouseEvent, useCallback, useRef, useState } from 'react';
+import { MouseEvent, ReactElement, useCallback, useRef, useState } from 'react';
 import useSWR from 'swr';
 import { Loader } from '../../components/common/Loader';
 import { Navigation } from '../../components/layouts/Navigation';
@@ -15,12 +14,14 @@ import { SectionMyInfo } from '../../components/SectionUserInfo';
 import { API_ENDPOINT, BORDER, Z_INDEX } from '../../constants';
 import { GRAY_900, WHITE, GRAY_300, PRIMARY } from '../../constants/colors';
 import { fetcher } from '../../utils';
+import { Layout } from '../../components/layouts/Layout';
+import { NextPageWithLayout } from '../_app';
 
 interface ModalProps {
   isShowModal: boolean;
 }
 
-const UserPage: NextPage = () => {
+const UserPage: NextPageWithLayout = () => {
   const accountname = Cookies.get('accountname') || '';
 
   const [isShowPopup, setIsShowPopup] = useState(false);
@@ -137,6 +138,15 @@ const UserPage: NextPage = () => {
         </ModalContainer>
       )}
     </>
+  );
+};
+
+UserPage.getLayout = function getLayout(page: ReactElement) {
+  return (
+    <Layout>
+      {page}
+      <Navigation />
+    </Layout>
   );
 };
 

--- a/src/pages/user/search.tsx
+++ b/src/pages/user/search.tsx
@@ -1,10 +1,9 @@
 import styled from '@emotion/styled';
-import { NextPage } from 'next';
 import Head from 'next/head';
-import Link from 'next/link';
-import { ChangeEventHandler, useState } from 'react';
+import { ChangeEventHandler, ReactElement, useState } from 'react';
 import useSWR from 'swr';
 import { Loader } from '../../components/common/Loader';
+import { Layout } from '../../components/layouts/Layout';
 import { Navigation } from '../../components/layouts/Navigation';
 import { ToolBar } from '../../components/layouts/ToolBar';
 import { UserAvatar } from '../../components/UserAvatar';
@@ -12,8 +11,9 @@ import { API_ENDPOINT, USER_AVATAR } from '../../constants';
 import { GRAY_200, GRAY_400, GRAY_900, PRIMARY } from '../../constants/colors';
 import { UserData } from '../../types/UserData';
 import { fetcher } from '../../utils';
+import { NextPageWithLayout } from '../_app';
 
-const SearchUser: NextPage = () => {
+const SearchUser: NextPageWithLayout = () => {
   const [keyword, setKeyword] = useState<string>('');
   const [userList, setUserList] = useState<UserData[]>([]);
 
@@ -82,6 +82,15 @@ const SearchUser: NextPage = () => {
         </ListUser>
       </MainSearch>
     </>
+  );
+};
+
+SearchUser.getLayout = function getLayout(page: ReactElement) {
+  return (
+    <Layout>
+      {page}
+      <Navigation />
+    </Layout>
   );
 };
 


### PR DESCRIPTION
## 개요
- 네비게이션 바 일부 페이지 노출되지 않게 수정

## 이슈 번호
#108 

## 작업 내용
- getLayout을 적용하여 네비게이션 바를 노출할 페이지와 그렇지 않은 페이지를 구분하여 적용
- 누락된 게시글 활성화 아이콘 추가 및 네비게이션에 적용

## 참고
- [Layouts](https://nextjs.org/docs/basic-features/layouts)
- [[NextJs] getLayout 적용하기](https://velog.io/@sssssssssy/getLayout)

